### PR TITLE
README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Uffizzi Quickstart for Kubernetes (~ 1 minute)
 
-Go from pull request to Uffizzi Preview Environment on Kubernetes in less than one minute...
+Go from pull request to Uffizzi Ephemeral Environment in less than one minute. This quickstart will create a virtual Kubernetes cluster on Uffizzi Cloud and deploy a sample microservices application from this repository. Once created, you can connect to the cluster with the Uffizzi CLI, then manage the cluster via Kubectl. You can clean up the cluster by closing the pull request or manually deleting it via the Uffizzi CLI.
 
 ### 1. Fork the `quickstart_k8s` repo
 
@@ -14,45 +14,46 @@ Select **Actions**, then select **I understand my workflows, go ahead and enable
 
 ### 3. Open a pull request for the `try-uffizzi` branch against `main` in your fork
 
-⚠️ Be sure that you're opening a PR on the branches of _your fork_ (i.e. `your-account/main` ← `your-account/try-uffizzi`).
+⚠️ Be sure that you're opening a PR on the branches of _your fork_ (i.e. `your-account/tree/main` ← `your-account/tree/try-uffizzi`).
 
-If you try to open a PR for `UffizziCloud/main` ← `your-account/try-uffizzi`, the Actions workflow will not run in this example.
+If you try to open a PR for `UffizziCloud/tree/main` ← `your-account/tree/try-uffizzi`, the Actions workflow will not run in this example.
 
-### 4. Open the completed action summary page
+### 4. View cluster details
+Once the action is finished running, check the pull request comments section to find information on how to access the newly created cluster.
 
-Under the Actions section of the forked repository, open up the latest completed action. Within the completed action, open up the summary section
+<img src="https://github.com/UffizziCloud/quickstart-k8s/blob/readme/images/comment.png" width="800">
 
 ### 5. Access the vote and result endpoints
 
-Copy and paste the vote and result endpoints within the action summary
+Additionally, the app endpoints can be found on the action summary page. Under the Actions section of the forked repository, open up the latest completed action. Within the completed action, open up the summary section. Copy and paste the vote and result endpoints within the action summary
 
 <img src="https://github.com/UffizziCloud/quickstart-k8s/blob/readme/images/quickstartss.png" width="800">
 
 ___
 ## What to expect
 
-The PR will trigger a [GitHub Actions workflow](.github/workflows/uffizzi-preview.yaml) that uses the Uffizzi CLI and Kubernetes manifests to create a Uffizzi Preview Environment for the [microservices application](#architecture-of-this-example-app) defined by this repo. The Preview Environment URL will be posted as a comment in your PR issue when the workflow completes.
+The PR will trigger a [GitHub Actions workflow](.github/workflows/uffizzi-cluster.yaml) that uses the Uffizzi CLI, and Kubernetes manifests to create a Uffizzi Ephemeral Environment for the [microservices application](#architecture-of-this-example-app) defined by this repo. When the workflow completes, the Ephemeral Environment URL will be posted as a comment in your PR issue.
 
 ## How it works
 
 ### Configuration
 
-Preview Environments are configured with [Kubernetes manifests](kustomization.yaml) that describe the application components and a [GitHub Actions workflow](.github/workflows/uffizzi-preview.yaml) that includes a series of jobs triggered by a `pull_request` event and subsequent `push` events:
+Ephemeral Environments are configured with [Kubernetes manifests](kustomization.yaml) that describe the application components and a [GitHub Actions workflow](.github/workflows/uffizzi-cluster.yaml) that includes a series of jobs triggered by a `pull_request` event and subsequent `push` events:
 
-1. [Build and push the voting-app images](https://github.com/UffizziCloud/quickstart-k8s/blob/c6123e3510e69a9433398eeb59482d19b920fcee/.github/workflows/create-ucluster.yaml#L11C3-L36C26)
-2. [Create the Uffizzi cluster using the uffizzi-cli](https://github.com/UffizziCloud/quickstart-k8s/blob/c6123e3510e69a9433398eeb59482d19b920fcee/.github/workflows/create-ucluster.yaml#L103C1-L112C36)
-3. [Apply the Kubernetes manifests to deploy the application to the Uffizzi cluster](https://github.com/UffizziCloud/quickstart-k8s/blob/c6123e3510e69a9433398eeb59482d19b920fcee/.github/workflows/create-ucluster.yaml#L125C1-L125C73)
-4. Delete the Preview Environment when the PR is merged/closed or after
+1. [Build and push the voting-app images](https://github.com/UffizziCloud/quickstart-k8s/blob/fc27d539d98fd602039a4259cafe9dd2ccf65dc5/.github/workflows/reusable.yml#L11C1-L90C28)
+2. [Create the Uffizzi cluster using the uffizzi-cli](https://github.com/UffizziCloud/quickstart-k8s/blob/fc27d539d98fd602039a4259cafe9dd2ccf65dc5/.github/workflows/reusable.yml#L92C1-L102C22)
+3. [Apply the Kubernetes manifests to deploy the application to the Uffizzi cluster](https://github.com/UffizziCloud/quickstart-k8s/blob/c6123e3510e69a9433398eeb59482d19b920fcee/.github/workflows/create-ucluster.yaml#L114C1-L125C73)
+4. [Delete the Ephemeral Environment when the PR is merged/closed or after](https://github.com/UffizziCloud/quickstart-k8s/blob/fc27d539d98fd602039a4259cafe9dd2ccf65dc5/.github/workflows/uffizzi-cluster.yaml#L143C1-L153C54)
 
 <!-- ### Uffizzi Cloud
 
-Running this workflow will create a [Uffizzi Cloud](https://uffizzi.com) account and project from your GitHub user and repo information, respectively. If you sign in to the [Uffizzi Dashboard](https://app.uffizzi.com/sign_in), you can view logs, password protect your Preview Environments, manage projects and team members, set role-based access controls, and configure single-sign-on (SSO).
+Running this workflow will create a [Uffizzi Cloud](https://uffizzi.com) account and project from your GitHub user and repo information, respectively. If you sign in to the [Uffizzi Dashboard](https://app.uffizzi.com/sign_in), you can view logs, password protect your Ephemeral Environments, manage projects and team members, set role-based access controls, and configure single-sign-on (SSO).
 
 Open-source projects preview for free on Uffizzi Cloud. All other accounts can subscribe to our Starter or Pro plans. See [our pricing](https://uffizzi.com/pricing) for details. If you're an open-source maintainer, you can request free access by sending an email to opensource@uffizzi.com. Alternatively, if you don't want to use Uffizzi Cloud, you can [install open-source Uffizzi](https://github.com/UffizziCloud/uffizzi_app/blob/develop/INSTALL.md) on your own Kubernetes cluster. -->
 
 ## Acceptable Use
 
-We strive to keep Uffizzi Cloud free or inexpensive for individuals and small teams. Therefore, activities such as crypto mining, file sharing, bots, and similar uses that lead to increased cost and intermittent issues for other users are strictly prohibited per the [Acceptable Use Policy](https://uffizzi.zendesk.com/hc/en-us/articles/4410657390999-Acceptable-Use-Policy). Violators of this policy are subject to permanent ban.
+We strive to keep Uffizzi Cloud free or inexpensive for individuals and small teams. Therefore, activities such as crypto mining, file sharing, bots, and similar uses that lead to increased costs and intermittent issues for other users are strictly prohibited per the [Acceptable Use Policy](https://www.uffizzi.com/legal/acceptable-use-policy). Violators of this policy are subject to permanent ban.
 
 ## Architecture of this Example App
 


### PR DESCRIPTION
- Replaced all instances of “Preview Environment” with “Ephemeral Environment”. 
-  Updated description to: “Go from pull request to Uffizzi Ephemeral Environment in less than one minute. This quickstart will create a virtual Kubernetes cluster on Uffizzi Cloud and deploy a sample microservices application from this repository. Once created, you can connect to the cluster with the uffizzi CLI, then manage the cluster via kubectl. You can clean up the cluster by closing the pull request or manually delete it via the uffizzi CLI.”
- Branch names now show your-account/tree/main and UffizziCloud/tree/main — i.e. include the …/tree/… in there since that is technical what the GitHub URLs show. 
- Steps 4 and 5 replaced with a call to see the PR comment. 
- Reviewed and replaced links 1-3, added link for step 4. 
- Updated Acceptable Use Policy link